### PR TITLE
Update README to show the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Issue Forms Body Parser
         id: parse
-        uses: zentered/issue-forms-body-parser@v2.0.0
+        uses: zentered/issue-forms-body-parser@v1.4.3
       - run: echo "${{ JSON.stringify(steps.parse.outputs.data) }}"
 ```
 


### PR DESCRIPTION
The README shows an example with v2.0.0. This is confusing for people trying to use this action. When you copy and paste the example into your workflow it does not work because v2.0.0 does not exist. Updating this to v1.4.3 allows users to copy and paste the example, and not have it complain about the version.