### PR TITLE
fix!: return null for empty No response fields

### DIFF
--- a/docs/superpowers/specs/2026-06-13-empty-field-null-design.md
+++ b/docs/superpowers/specs/2026-06-13-empty-field-null-design.md
@@ -6,8 +6,10 @@ Related issue:
 ## Problem
 
 GitHub Issue Forms render an optional field that was left blank as the literal
-markdown `_No response_`. The parser currently treats this like any other
-paragraph, producing:
+markdown `_No response_`. By the time `parse.js` re-stringifies the paragraph
+with `remark-stringify`'s default emphasis marker, `_No response_` is normalized
+to `*No response*`. The parser currently treats this like any other paragraph,
+producing:
 
 ```json
 "field": {
@@ -25,7 +27,13 @@ consumers to special-case the string `*No response*`.
 
 In `src/parse.js`, inside the `paragraph` branch, after computing `cleanText`:
 
-1. If `cleanText === '*No response*'`, treat the field as empty:
+1. If the trimmed `cleanText` is `*No response*` or `_No response_`, treat the
+   field as empty:
+   - Matching both forms covers `remark-stringify`'s default asterisk emphasis
+     (the normal case for the GitHub Issue Forms placeholder) as well as the
+     underscore form, which can occur if `cleanText` contains escaped
+     underscores that get unescaped back to `_No response_` by the `\\_` cleanup
+     step earlier in the loop.
    - Do not run date/time/duration/links/images parsing on it.
    - Do not push it into `obj.content`.
    - Set `obj.text = null` directly.
@@ -34,9 +42,9 @@ In `src/parse.js`, inside the `paragraph` branch, after computing `cleanText`:
 ### Why this is sufficient
 
 The closing loop in `parse.js` (the `for (const key in structuredResponse)`
-block) only overwrites `token.text` when `content.length > 0`. Since the
-`*No response*` paragraph is never pushed to `content`, `content` stays `[]`,
-and the explicit `obj.text = null` set above is preserved.
+block) only overwrites `token.text` when `content.length > 0`. Since the "No
+response" placeholder paragraph is never pushed to `content`, `content` stays
+`[]`, and the explicit `obj.text = null` set above is preserved.
 
 ### Resulting shape
 
@@ -70,6 +78,11 @@ Update `test/parse-issue.test.js` expectations for:
 - `repository-justification` (same)
 
 Both become `content: [], text: null`.
+
+Add a fixture field whose raw markdown contains escaped underscores
+(`\_No response\_`), which `parse.js` unescapes back to `_No response_` before
+the placeholder check. This covers the underscore branch of the check added
+above, expecting `content: [], text: null`.
 
 ## Versioning
 

--- a/docs/superpowers/specs/2026-06-13-empty-field-null-design.md
+++ b/docs/superpowers/specs/2026-06-13-empty-field-null-design.md
@@ -1,0 +1,79 @@
+# Design: Return `null` for empty ("No response") fields
+
+Related issue:
+[#40](https://github.com/zentered/issue-forms-body-parser/issues/40)
+
+## Problem
+
+GitHub Issue Forms render an optional field that was left blank as the literal
+markdown `_No response_`. The parser currently treats this like any other
+paragraph, producing:
+
+```json
+"field": {
+  "title": "field",
+  "heading": 3,
+  "content": ["*No response*"],
+  "text": "*No response*"
+}
+```
+
+This leaks an internal markdown placeholder into the structured output, forcing
+consumers to special-case the string `*No response*`.
+
+## Solution
+
+In `src/parse.js`, inside the `paragraph` branch, after computing `cleanText`:
+
+1. If `cleanText === '*No response*'`, treat the field as empty:
+   - Do not run date/time/duration/links/images parsing on it.
+   - Do not push it into `obj.content`.
+   - Set `obj.text = null` directly.
+2. Otherwise, process the paragraph as today.
+
+### Why this is sufficient
+
+The closing loop in `parse.js` (the `for (const key in structuredResponse)`
+block) only overwrites `token.text` when `content.length > 0`. Since the
+`*No response*` paragraph is never pushed to `content`, `content` stays `[]`,
+and the explicit `obj.text = null` set above is preserved.
+
+### Resulting shape
+
+```json
+"field": {
+  "title": "field",
+  "heading": 3,
+  "content": [],
+  "text": null
+}
+```
+
+## Edge cases
+
+- **Checkbox / task lists**: GitHub always renders a checked/unchecked state for
+  these, never `_No response_`. No change needed in the `list` branch.
+- **Code-block fields** (e.g. fields with a code-language hint): an empty
+  textarea renders as a `_No response_` paragraph, not an empty code block.
+  Already covered by the paragraph branch.
+- **Multiple paragraphs under one heading where only one is `*No response*`**
+  (unlikely in practice, since GitHub Issue Forms map one field to one
+  paragraph): only the `*No response*` paragraph is skipped; remaining
+  paragraphs are joined normally.
+
+## Testing
+
+Update `test/parse-issue.test.js` expectations for:
+
+- `repository-description` (currently
+  `content: ['*No response*'], text: '*No response*'`)
+- `repository-justification` (same)
+
+Both become `content: [], text: null`.
+
+## Versioning
+
+This changes the type of `.text` for previously-empty fields from `string` to
+`null`. Consumers calling string methods on `.text` for an empty field would
+break. Commit as `fix!:` with a `BREAKING CHANGE:` footer, triggering a major
+version bump per semantic-release.

--- a/src/parse.js
+++ b/src/parse.js
@@ -51,7 +51,8 @@ export default async function parseMD(body) {
     } else if (token.type === 'paragraph' && currentHeading) {
       const obj = structuredResponse[currentHeading]
 
-      if (cleanText === '*No response*') {
+      const trimmedText = cleanText.trim()
+      if (trimmedText === '*No response*' || trimmedText === '_No response_') {
         obj.text = null
         continue
       }

--- a/src/parse.js
+++ b/src/parse.js
@@ -51,6 +51,11 @@ export default async function parseMD(body) {
     } else if (token.type === 'paragraph' && currentHeading) {
       const obj = structuredResponse[currentHeading]
 
+      if (cleanText === '*No response*') {
+        obj.text = null
+        continue
+      }
+
       const date = parseDate(cleanText)
       const images = parseImages(token.children)
       const links = parseLinks(token.children)

--- a/test/parse-issue.test.js
+++ b/test/parse-issue.test.js
@@ -156,6 +156,12 @@ test('parse(md) should parse GitHub Issue Form data into useful, structured data
       heading: 3,
       content: ['@tinyfists/under_scores'],
       text: '@tinyfists/under_scores'
+    },
+    'repository-notes': {
+      title: 'Repository notes',
+      heading: 3,
+      content: [],
+      text: null
     }
   }
 

--- a/test/parse-issue.test.js
+++ b/test/parse-issue.test.js
@@ -136,8 +136,8 @@ test('parse(md) should parse GitHub Issue Form data into useful, structured data
     'repository-description': {
       title: 'Repository description',
       heading: 3,
-      content: ['*No response*'],
-      text: '*No response*'
+      content: [],
+      text: null
     },
     'repository-visibility': {
       title: 'Repository visibility',
@@ -148,8 +148,8 @@ test('parse(md) should parse GitHub Issue Form data into useful, structured data
     'repository-justification': {
       title: 'Repository justification',
       heading: 3,
-      content: ['*No response*'],
-      text: '*No response*'
+      content: [],
+      text: null
     },
     'repository-access': {
       title: 'Repository access',

--- a/test/test-issue-1.md
+++ b/test/test-issue-1.md
@@ -74,3 +74,7 @@ _No response_
 ### Repository access
 
 @tinyfists/under_scores
+
+### Repository notes
+
+\_No response\_


### PR DESCRIPTION
## Summary

- GitHub Issue Forms render blank optional fields as the literal markdown `*No response*`, which previously leaked into the structured output (`content: ['*No response*']`, `text: '*No response*'`).
- `parse.js` now detects this placeholder in the paragraph branch, skips date/time/duration/links/images parsing for it, leaves `content` empty, and sets `text: null`.
- Adds the design doc (`docs/superpowers/specs/2026-06-13-empty-field-null-design.md`) and updates test fixtures for `repository-description` / `repository-justification`.

Closes #40

## Breaking change

`BREAKING CHANGE:` `.text` for previously-empty fields is now `null` instead of the string `*No response*`. Consumers calling string methods on `.text` for empty fields will need to handle `null`.

## Test plan

- [x] `npm test` passes
- [ ] Reviewer confirms the new `null`/`[]` shape is the desired consumer-facing contract