### PR TITLE
ci: enable npm OIDC trusted publishing for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ permissions:
   deployments: write
   issues: read
   pull-requests: write
+  id-token: write
 
 on:
   push:
@@ -15,13 +16,12 @@ jobs:
   test:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the publish workflow
- Bumps Node to 24 (bundles npm >= 11.5.1, required for npm trusted publishing)
- Removes the `NPM_TOKEN` secret usage; `@semantic-release/npm` will authenticate via OIDC trusted publishing instead

## Test plan
- [ ] Confirm npm trusted publisher is configured for `@zentered/issue-forms-body-parser` (this repo + `.github/workflows/publish.yml`)
- [ ] Merge and verify the next release publishes successfully without `NPM_TOKEN`
- [ ] Remove the `NPM_TOKEN` secret from repo settings once confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)